### PR TITLE
Adding support for dh895xcc devices

### DIFF
--- a/cmd/qat2_plugin/qat2_plugin.go
+++ b/cmd/qat2_plugin/qat2_plugin.go
@@ -148,8 +148,13 @@ func (dp *devicePlugin) parseConfigs() (map[string]section, error) {
 		devprops := strings.Split(devstr[1], ",")
 		devType := ""
 		for _, propstr := range devprops {
-			if strings.TrimSpace(propstr) == "type: c6xx" {
-				devType = "c6xx"
+			switch strings.TrimSpace(propstr) {
+				// Embeded in Chipset c62x.
+				case "type: c6xx":
+					devType = "c6xx"
+				// Cards with communication chipset 8925-8955.
+				case "type: dh895xcc":
+					devType = "dh895xcc"
 			}
 		}
 


### PR DESCRIPTION
This commit adds the possibility to qat2_plugin use pci,
devices with communication chipset 8925 to 8955.

Signed-off-by: Rivera Gonzalez, Julio C <julio.c.rivera.gonzalez@intel.com>